### PR TITLE
Add integration for FloodLights

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -56,6 +56,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.7.18-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:OpenComputers:1.11.4-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:waila:1.8.2:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:FloodLights:1.4.5:dev") { transitive = false }
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-521-GTNH:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.73:dev")
@@ -64,6 +65,7 @@ dependencies {
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.18-GTNH:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Hodgepodge:2.6.15:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForgeMultipart:1.6.2:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:FloodLights:1.4.5:dev")
 
     compileOnly deobf("https://www.immibis.com/mcmoddl/files/immibis-microblocks-59.1.2.jar", "immibis-microblocks-59.1.2")
     compileOnly deobf("https://www.immibis.com/mcmoddl/files/immibis-core-59.1.4.jar", "immibis-core-59.1.4")

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/AbstractBuildable.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/AbstractBuildable.java
@@ -84,7 +84,7 @@ public abstract class AbstractBuildable extends MMInventory implements IBuildabl
 
         try {
             Block block = spec.getBlock();
-            if (block.isBlockContainer) {
+            if (block.hasTileEntity(spec.getBlockMeta())) {
                 euUsage *= TE_PENALTY;
             }
         } catch (Throwable e) {

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/CopyableProperty.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/CopyableProperty.java
@@ -14,6 +14,9 @@ public enum CopyableProperty {
     TEXT,
     ORIENTATION,
     DELAY,
+    INVERTED,
+    COLOR,
+    ROTATION_STATE,
     ;
 
     public static final ImmutableList<CopyableProperty> VALUES = ImmutableList.copyOf(values());

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
@@ -176,7 +176,7 @@ public class BlockPropertyRegistry {
         if (Mods.StorageDrawers.isModLoaded()) initStorageDrawers();
         if (Mods.IndustrialCraft2.isModLoaded()) initIC2();
         if (Mods.ArchitectureCraft.isModLoaded()) initArch();
-        if (Mods.FloogLights.isModLoaded()) initFloodLights();
+        if (Mods.FloodLights.isModLoaded()) initFloodLights();
     }
 
     // #region Vanilla

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
@@ -46,12 +46,12 @@ import com.recursive_pineapple.matter_manipulator.common.utils.MMUtils;
 import com.recursive_pineapple.matter_manipulator.common.utils.Mods;
 import com.recursive_pineapple.matter_manipulator.common.utils.Mods.Names;
 
+import de.keridos.floodlights.tileentity.TileEntityMetaFloodlight;
+import de.keridos.floodlights.tileentity.TileEntitySmallFloodlight;
 import gcewing.architecture.common.tile.TileArchitecture;
 import ic2.api.tile.IWrenchable;
 import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-import scala.tools.nsc.typechecker.MethodSynthesis.MethodSynth.Getter;
-import scala.tools.nsc.typechecker.MethodSynthesis.MethodSynth.Setter;
 
 public class BlockPropertyRegistry {
 
@@ -176,6 +176,7 @@ public class BlockPropertyRegistry {
         if (Mods.StorageDrawers.isModLoaded()) initStorageDrawers();
         if (Mods.IndustrialCraft2.isModLoaded()) initIC2();
         if (Mods.ArchitectureCraft.isModLoaded()) initArch();
+        if (Mods.FloogLights.isModLoaded()) initFloodLights();
     }
 
     // #region Vanilla
@@ -844,6 +845,131 @@ public class BlockPropertyRegistry {
                 }
             }
         );
+    }
+
+    // #endregion
+
+    // #region FloodLights
+
+    private static void initFloodLights() {
+        registerTileEntityInterfaceProperty(TileEntityMetaFloodlight.class, new AbstractDirectionBlockProperty("facing") {
+
+            @Override
+            public ForgeDirection getValue(World world, int x, int y, int z) {
+                if (!(world.getTileEntity(x, y, z) instanceof TileEntityMetaFloodlight floodlight)) return UNKNOWN;
+
+                return floodlight.getOrientation();
+            }
+
+            @Override
+            public void setValue(World world, int x, int y, int z, ForgeDirection forgeDirection) {
+                // Do the same thing FloodLights do in `onBlockPlacedBy`
+                if (!(world.getTileEntity(x, y, z) instanceof TileEntityMetaFloodlight floodlight)) return;
+
+                floodlight.setOrientation(forgeDirection);
+
+                if (!(floodlight instanceof TileEntitySmallFloodlight)) {
+                    // copy rotation info into metadata because FloodLights does it too
+                    world.setBlockMetadataWithNotify(x, y, z, forgeDirection.ordinal(), 2);
+                } else {
+                    // NB: small electric light does not use metadata for rotation
+                    // instead, it uses it to discern normal/small floodlights
+                    // so don't modify metadata, just update it
+                    world.markBlockForUpdate(x, y, z);
+                }
+            }
+        });
+
+        registerTileEntityInterfaceProperty(TileEntityMetaFloodlight.class, new BooleanProperty() {
+
+            @Override
+            public String getName() {
+                return "inverted";
+            }
+
+            @Override
+            public boolean getBoolean(World world, int x, int y, int z) {
+                if (!(world.getTileEntity(x, y, z) instanceof TileEntityMetaFloodlight floodlight)) return false;
+
+                return floodlight.getInverted();
+            }
+
+            @Override
+            public void setBoolean(World world, int x, int y, int z, boolean value) {
+                if (!(world.getTileEntity(x, y, z) instanceof TileEntityMetaFloodlight floodlight)) return;
+
+                if (floodlight.getInverted() != value) {
+                    floodlight.toggleInverted();
+                }
+            }
+        });
+
+        registerTileEntityInterfaceProperty(TileEntityMetaFloodlight.class, new IntegerProperty() {
+
+            @Override
+            public String getName() {
+                return "mode";
+            }
+
+            @Override
+            public int getInt(World world, int x, int y, int z) {
+                if (!(world.getTileEntity(x, y, z) instanceof TileEntityMetaFloodlight floodlight)) return 0;
+
+                return floodlight.getMode();
+            }
+
+            @Override
+            public void setInt(World world, int x, int y, int z, int value) {
+                if (!(world.getTileEntity(x, y, z) instanceof TileEntityMetaFloodlight floodlight)) return;
+
+                floodlight.setMode(value);
+            }
+        });
+
+        registerTileEntityInterfaceProperty(TileEntityMetaFloodlight.class, new IntegerProperty() {
+
+            @Override
+            public String getName() {
+                return "color";
+            }
+
+            @Override
+            public int getInt(World world, int x, int y, int z) {
+                if (!(world.getTileEntity(x, y, z) instanceof TileEntityMetaFloodlight floodlight)) return 0;
+
+                return floodlight.getColor();
+            }
+
+            @Override
+            public void setInt(World world, int x, int y, int z, int value) {
+                if (!(world.getTileEntity(x, y, z) instanceof TileEntityMetaFloodlight floodlight)) return;
+
+                floodlight.setColor(value);
+            }
+        });
+
+        registerTileEntityInterfaceProperty(TileEntitySmallFloodlight.class, new BooleanProperty() {
+
+            @Override
+            public String getName() {
+                return "rotation_state";
+            }
+
+            @Override
+            public boolean getBoolean(World world, int x, int y, int z) {
+                if (!(world.getTileEntity(x, y, z) instanceof TileEntitySmallFloodlight floodlight)) return false;
+
+                return floodlight.getRotationState();
+            }
+
+            @Override
+            public void setBoolean(World world, int x, int y, int z, boolean value) {
+                if (!(world.getTileEntity(x, y, z) instanceof TileEntitySmallFloodlight floodlight)) return;
+
+                floodlight.setRotationState(value);
+                world.markBlockForUpdate(x, y, z);
+            }
+        });
     }
 
     // #endregion

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
@@ -131,7 +131,7 @@ public class BlockPropertyRegistry {
 
         properties.putAll(props);
 
-        if (block.isBlockContainer) {
+        if (block.hasTileEntity(world.getBlockMetadata(x, y, z))) {
             TileEntity tile = world.getTileEntity(x, y, z);
 
             if (tile != null) {
@@ -154,7 +154,7 @@ public class BlockPropertyRegistry {
         BlockProperty<?> prop = props.get(name);
         if (prop != null) return prop;
 
-        if (block.isBlockContainer) {
+        if (block.hasTileEntity(world.getBlockMetadata(x, y, z))) {
             TileEntity tile = world.getTileEntity(x, y, z);
 
             if (tile != null) {

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
@@ -19,6 +19,7 @@ public enum Mods {
     ForgeMicroblocks(Names.FORGE_MICROBLOCKS),
     /** The forge multipart library. */
     ForgeMultipart(Names.FORGE_MULTIPART),
+    FloogLights(Names.FLOOD_LIGHTS),
     GregTech(Names.GREG_TECH),
     GTPlusPlus(Names.G_T_PLUS_PLUS),
     GraviSuite(Names.GRAVI_SUITE),
@@ -51,6 +52,7 @@ public enum Mods {
         public static final String ENDER_I_O = "EnderIO";
         public static final String FORGE_MICROBLOCKS = "ForgeMicroblock";
         public static final String FORGE_MULTIPART = "ForgeMultipart";
+        public static final String FLOOD_LIGHTS = "FloodLights";
         public static final String GREG_TECH = "gregtech";
         public static final String GRAVI_SUITE = "GraviSuite";
         public static final String G_T_PLUS_PLUS = "miscutils";

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
@@ -19,7 +19,7 @@ public enum Mods {
     ForgeMicroblocks(Names.FORGE_MICROBLOCKS),
     /** The forge multipart library. */
     ForgeMultipart(Names.FORGE_MULTIPART),
-    FloogLights(Names.FLOOD_LIGHTS),
+    FloodLights(Names.FLOOD_LIGHTS),
     GregTech(Names.GREG_TECH),
     GTPlusPlus(Names.G_T_PLUS_PLUS),
     GraviSuite(Names.GRAVI_SUITE),


### PR DESCRIPTION
This preserves floodlights settings like orientation, mode, redstone inversion, color and, for small floodlights, rotation state.

Tested by copying & pasting this set of floodlights. Some of them are inverted, the cluster of blocks on the left is flipped.

![image](https://github.com/user-attachments/assets/9bab8c08-c7c5-4ea7-befd-8bbbacaa5694)

Also tested without the FloodLights mod, no crashes there.

Depends on https://github.com/GTNewHorizons/FloodLights/pull/12, since MatterManipulator will not try to get block properties based on TE type if `isBlockContainer` is false.