### PR TITLE
Improved exchanging

### DIFF
--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/MMUtils.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/MMUtils.java
@@ -1320,6 +1320,15 @@ public class MMUtils {
     }
 
     @Optional(Names.GREG_TECH)
+    public static boolean isGTMachine(ImmutableBlockSpec spec) {
+        if (spec.getBlock() instanceof BlockMachines) {
+            if (getIndexSafe(GregTechAPI.METATILEENTITIES, spec.getMeta()) != null) { return true; }
+        }
+
+        return false;
+    }
+
+    @Optional(Names.GREG_TECH)
     public static boolean isGTCable(ImmutableBlockSpec spec) {
         if (spec.getBlock() instanceof BlockMachines) {
             if (getIndexSafe(GregTechAPI.METATILEENTITIES, spec.getMeta()) instanceof IConnectable) { return true; }


### PR DESCRIPTION
Exchanging will now keep all possible settings from prior blocks (including rotation for energy hatches). You can also replace air now.
