### PR TITLE
Prevent AE cable removal when replace impossible

### DIFF
--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/ItemMatterManipulator.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/ItemMatterManipulator.java
@@ -938,7 +938,7 @@ public class ItemMatterManipulator extends Item implements ISpecialElectricItem,
 
     private void checkForAECables(BlockSpec spec, World world, int x, int y, int z) {
         if (tier.hasCap(ALLOW_CABLES) && AppliedEnergistics2.isModLoaded()) {
-            if (spec.getItem() == MMUtils.AE_BLOCK_CABLE.get().getItem()) {
+            if (MMUtils.AE_BLOCK_CABLE.matches(spec)) {
                 MMUtils.getAECable(spec, world, x, y, z);
             }
         }
@@ -1539,13 +1539,11 @@ public class ItemMatterManipulator extends Item implements ISpecialElectricItem,
                 if (t.flipY) flips.add("Y");
                 if (t.flipZ) flips.add("Z");
 
-                String[] names = { "Down", "Up", "North", "South", "West", "East" };
-
                 return String.format(
                     "Flip: %s\nUp: %s\nForward: %s",
                     flips.isEmpty() ? "None" : String.join(", ", flips),
-                    names[t.up.ordinal()],
-                    names[t.forward.ordinal()]);
+                    MMUtils.getDirectionDisplayName(t.up),
+                    MMUtils.getDirectionDisplayName(t.forward));
             });
 
             Widget[] left = {

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/MMUtils.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/MMUtils.java
@@ -1375,4 +1375,20 @@ public class MMUtils {
 
         return false;
     }
+
+    public static String getDirectionDisplayName(ForgeDirection dir) {
+        return getDirectionDisplayName(dir, false);
+    }
+
+    public static String getDirectionDisplayName(ForgeDirection dir, boolean unknownIsCentre) {
+        return switch (dir) {
+            case DOWN -> "Down";
+            case EAST -> "East";
+            case NORTH -> "North";
+            case SOUTH -> "South";
+            case UNKNOWN -> unknownIsCentre ? "Center" : "Unknown";
+            case UP -> "Up";
+            case WEST -> "West";
+        };
+    }
 }


### PR DESCRIPTION
MM would previously remove cables even when the replacing cable wasn't available or couldn't fit (ie small -> dense w/ parts). This stops that from happening so that the old cables won't be removed, preventing the setup from getting mangled.
