### PR TITLE
Mitigate keybind conflicts

### DIFF
--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/MMKeyInputs.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/MMKeyInputs.java
@@ -5,6 +5,8 @@ import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
+import net.minecraftforge.client.event.MouseEvent;
+
 import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.InputEvent.KeyInputEvent;
@@ -102,5 +104,26 @@ public class MMKeyInputs {
         }
 
         return;
+    }
+
+    /**
+     * For some reason, the key bindings will be phantom pressed if you change your hotbar while they're pressed.
+     * If you do the following, it will act up.
+     * <ol>
+     * <li>Bind hotbar 1 to C</li>
+     * <li>Press C</li>
+     * <li>Scroll back to the manipulator</li>
+     * <li>Press control</li>
+     * <li>Magically presses C somehow</li>
+     * </ol>
+     */
+    @SubscribeEvent
+    public static void onMouseScroll(MouseEvent event) {
+        if (event.dwheel == 0) return;
+
+        CUT.unpressKey();
+        COPY.unpressKey();
+        PASTE.unpressKey();
+        RESET.unpressKey();
     }
 }

--- a/src/main/resources/META-INF/mm_at.cfg
+++ b/src/main/resources/META-INF/mm_at.cfg
@@ -9,3 +9,5 @@ public net.minecraft.client.particle.EffectRenderer field_78876_b # fxLayers
 public net.minecraft.tileentity.TileEntitySkull field_145910_i # rotation
 
 public net.minecraft.block.Block func_149642_a(Lnet/minecraft/world/World;IIILnet/minecraft/item/ItemStack;)V # dropBlockAsItem
+
+public net.minecraft.client.settings.KeyBinding func_74505_d()V # unpressKey

--- a/src/mixin/java/com/recursive_pineapple/matter_manipulator/mixin/mixins/early/MixinKeyBinding.java
+++ b/src/mixin/java/com/recursive_pineapple/matter_manipulator/mixin/mixins/early/MixinKeyBinding.java
@@ -1,0 +1,76 @@
+package com.recursive_pineapple.matter_manipulator.mixin.mixins.early;
+
+import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.recursive_pineapple.matter_manipulator.MMMod;
+import com.recursive_pineapple.matter_manipulator.common.items.manipulator.ItemMatterManipulator;
+import com.recursive_pineapple.matter_manipulator.common.items.manipulator.MMKeyInputs;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+/**
+ * Cancel mm key presses for conflicting keybinds when the player is holding a manipulator.
+ */
+@Mixin(KeyBinding.class)
+public class MixinKeyBinding {
+
+    @ModifyReturnValue(method = "getIsKeyPressed", at = @At("RETURN"))
+    public boolean mm$cancelGetIsKeyPressed(boolean pressed) {
+        KeyBinding self = (KeyBinding) (Object) this;
+
+        if (self == MMKeyInputs.CONTROL) return pressed;
+        if (self == MMKeyInputs.CUT) return pressed;
+        if (self == MMKeyInputs.COPY) return pressed;
+        if (self == MMKeyInputs.PASTE) return pressed;
+        if (self == MMKeyInputs.RESET) return pressed;
+
+        if (MMKeyInputs.CONTROL.getKeyCode() == 0 || MMKeyInputs.CONTROL.getIsKeyPressed()) {
+            EntityPlayer player = MMMod.proxy.getThePlayer();
+
+            if (player != null) {
+                ItemStack held = player.getHeldItem();
+    
+                if (held != null && held.getItem() instanceof ItemMatterManipulator) {
+                    if (self.getKeyCode() == MMKeyInputs.CUT.getKeyCode()) return false;
+                    if (self.getKeyCode() == MMKeyInputs.COPY.getKeyCode()) return false;
+                    if (self.getKeyCode() == MMKeyInputs.PASTE.getKeyCode()) return false;
+                    if (self.getKeyCode() == MMKeyInputs.RESET.getKeyCode()) return false;
+                }
+            }
+        }
+
+        return pressed;
+    }
+
+    @ModifyReturnValue(method = "isPressed", at = @At("RETURN"))
+    public boolean mm$cancelIsPressed(boolean pressed) {
+        KeyBinding self = (KeyBinding) (Object) this;
+
+        if (self == MMKeyInputs.CONTROL) return pressed;
+        if (self == MMKeyInputs.CUT) return pressed;
+        if (self == MMKeyInputs.COPY) return pressed;
+        if (self == MMKeyInputs.PASTE) return pressed;
+        if (self == MMKeyInputs.RESET) return pressed;
+
+        if (MMKeyInputs.CONTROL.getKeyCode() == 0 || MMKeyInputs.CONTROL.getIsKeyPressed()) {
+            EntityPlayer player = MMMod.proxy.getThePlayer();
+            
+            if (player != null) {
+                ItemStack held = player.getHeldItem();
+    
+                if (held != null && held.getItem() instanceof ItemMatterManipulator) {
+                    if (self.getKeyCode() == MMKeyInputs.CUT.getKeyCode()) return false;
+                    if (self.getKeyCode() == MMKeyInputs.COPY.getKeyCode()) return false;
+                    if (self.getKeyCode() == MMKeyInputs.PASTE.getKeyCode()) return false;
+                    if (self.getKeyCode() == MMKeyInputs.RESET.getKeyCode()) return false;
+                }
+            }
+        }
+
+        return pressed;
+    }
+}


### PR DESCRIPTION
This will prevent conflicting keybinds from activating when holding a manipulator. MM keybinds take priority over all others. While this will fix 99% of conflicts, some mods may use a lower-level mechanism for checking keypresses, which can't be intercepted without a much more invasive change.
