### PR TITLE
Specifically check that the NH fork of GT is loaded

### DIFF
--- a/src/main/java/com/recursive_pineapple/matter_manipulator/CommonProxy.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/CommonProxy.java
@@ -27,8 +27,7 @@ public class CommonProxy {
 
     public void init(FMLInitializationEvent event) {
         EntityItemLarge.registerCommon();
-
-        if (Mods.AppliedEnergistics2.isModLoaded() && Mods.GregTech.isModLoaded()) {
+        if (Mods.AppliedEnergistics2.isModLoaded() && Mods.GregTechNH.isModLoaded()) {
             MMItems.registerMultis();
         }
 

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/AbstractBuildable.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/AbstractBuildable.java
@@ -208,7 +208,7 @@ public abstract class AbstractBuildable extends MMInventory implements IBuildabl
     }
 
     @Optional({
-        Names.GREG_TECH, Names.APPLIED_ENERGISTICS2
+        Names.GREG_TECH_NH, Names.APPLIED_ENERGISTICS2
     })
     protected void emptySuperchest(TileEntity te) {
         if (te instanceof IGregTechTileEntity igte && igte.getMetaTileEntity() instanceof MTEDigitalChestBase dchest) {
@@ -233,7 +233,7 @@ public abstract class AbstractBuildable extends MMInventory implements IBuildabl
     }
 
     @Optional({
-        Names.GREG_TECH, Names.APPLIED_ENERGISTICS2
+        Names.GREG_TECH_NH, Names.APPLIED_ENERGISTICS2
     })
     protected void emptyMEOutput(TileEntity te) {
         if (te instanceof IGregTechTileEntity igte) {
@@ -279,7 +279,7 @@ public abstract class AbstractBuildable extends MMInventory implements IBuildabl
         }
     }
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     protected void removeCovers(TileEntity te) {
         if (te instanceof ICoverable coverable) {
             for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
@@ -366,7 +366,7 @@ public abstract class AbstractBuildable extends MMInventory implements IBuildabl
         }
     }
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     protected void resetGTMachine(TileEntity te) {
         if (te instanceof IRedstoneEmitter emitter) {
             for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/AbstractBuildable.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/AbstractBuildable.java
@@ -164,7 +164,7 @@ public abstract class AbstractBuildable extends MMInventory implements IBuildabl
         TileEntity te = world.getTileEntity(x, y, z);
 
         boolean ae = Mods.AppliedEnergistics2.isModLoaded();
-        boolean gt = Mods.GregTech.isModLoaded();
+        boolean gt = Mods.GregTechNH.isModLoaded();
         boolean eio = Mods.EnderIO.isModLoaded();
 
         if (ae && gt) emptySuperchest(te);

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/InteropConstants.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/InteropConstants.java
@@ -61,7 +61,7 @@ public class InteropConstants {
         return true;
     }
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     private static boolean isGTRenderer(Block block) {
         if (block == GregTechAPI.sDroneRender) return true;
         if (block == GregTechAPI.sWormholeRender) return true;

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/InteropConstants.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/InteropConstants.java
@@ -43,7 +43,7 @@ public class InteropConstants {
     public static boolean skipWhenCopying(Block block, int meta) {
         if (block.getMaterial() instanceof MaterialLiquid) return true;
 
-        if (Mods.GregTech.isModLoaded() && isGTRenderer(block)) return true;
+        if (Mods.GregTechNH.isModLoaded() && isGTRenderer(block)) return true;
         if (FMP_BLOCK.matches(block, meta)) return true;
         if (BRIGHT_AIR.matches(block, meta)) return true;
         if (ARCANE_LAMP_LIGHT.matches(block, meta)) return true;
@@ -52,7 +52,7 @@ public class InteropConstants {
     }
 
     public static boolean shouldDropItem(Block block, int meta) {
-        if (Mods.GregTech.isModLoaded() && isGTRenderer(block)) return false;
+        if (Mods.GregTechNH.isModLoaded() && isGTRenderer(block)) return false;
 
         // Don't check for MaterialTransparent because it could include things like nitor
         if (BRIGHT_AIR.matches(block, meta)) return false;

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/MMInventory.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/MMInventory.java
@@ -561,7 +561,7 @@ public class MMInventory implements IPseudoInventory {
         }
     }
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     private void consumeItemsFromUplink(
         List<BigItemStack> requestedItems,
         List<BigItemStack> extractedItems,

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/MMInventory.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/MMInventory.java
@@ -86,7 +86,7 @@ public class MMInventory implements IPseudoInventory {
             if (state.hasCap(ItemMatterManipulator.CONNECTS_TO_AE) && Mods.AppliedEnergistics2.isModLoaded()) {
                 consumeItemsFromAE(simulated, extracted, flags | CONSUME_SIMULATED);
             }
-            if (state.hasCap(ItemMatterManipulator.CONNECTS_TO_UPLINK) && Mods.GregTech.isModLoaded()) {
+            if (state.hasCap(ItemMatterManipulator.CONNECTS_TO_UPLINK) && Mods.GregTechNH.isModLoaded()) {
                 consumeItemsFromUplink(simulated, extracted, flags | CONSUME_SIMULATED);
             }
 
@@ -107,7 +107,7 @@ public class MMInventory implements IPseudoInventory {
             if (state.hasCap(ItemMatterManipulator.CONNECTS_TO_AE) && Mods.AppliedEnergistics2.isModLoaded()) {
                 consumeItemsFromAE(simulated, extracted, flags);
             }
-            if (state.hasCap(ItemMatterManipulator.CONNECTS_TO_UPLINK) && Mods.GregTech.isModLoaded()) {
+            if (state.hasCap(ItemMatterManipulator.CONNECTS_TO_UPLINK) && Mods.GregTechNH.isModLoaded()) {
                 consumeItemsFromUplink(simulated, extracted, flags);
             }
 

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/PendingBlock.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/PendingBlock.java
@@ -409,7 +409,7 @@ public class PendingBlock extends Location {
 
     public PendingBlock analyze(TileEntity te, int flags) {
         if (te != null) {
-            if ((flags & ANALYZE_GT) != 0 && Mods.GregTech.isModLoaded()) {
+            if ((flags & ANALYZE_GT) != 0 && Mods.GregTechNH.isModLoaded()) {
                 this.gt = GTAnalysisResult.analyze(te);
             }
 

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/PendingBuild.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/PendingBuild.java
@@ -564,7 +564,7 @@ public class PendingBuild extends AbstractBuildable {
         }
     }
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     private String getGTBlockName(PendingBlock pendingBlock) {
         if (player.worldObj.getTileEntity(pendingBlock.x, pendingBlock.y, pendingBlock.z) instanceof IGregTechTileEntity igte) {
             IMetaTileEntity imte = igte.getMetaTileEntity();

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/PendingBuild.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/PendingBuild.java
@@ -422,7 +422,7 @@ public class PendingBuild extends AbstractBuildable {
     }
 
     private ForgeDirection getDefaultPlaceSide(ImmutableBlockSpec spec) {
-        if (Mods.GregTech.isModLoaded() && MMUtils.isGTCable(spec)) { return ForgeDirection.UNKNOWN; }
+        if (Mods.GregTechNH.isModLoaded() && MMUtils.isGTCable(spec)) { return ForgeDirection.UNKNOWN; }
 
         return ForgeDirection.NORTH;
     }

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/PendingMove.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/PendingMove.java
@@ -329,7 +329,7 @@ public class PendingMove extends AbstractBuildable {
             newTileEntityF.yCoord = sy;
             newTileEntityF.zCoord = sz;
 
-            if (Mods.GregTech.isModLoaded()) {
+            if (Mods.GregTechNH.isModLoaded()) {
                 updateGTIfNeeded(newTileEntityF);
             }
         }

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/PendingMove.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/building/PendingMove.java
@@ -337,7 +337,7 @@ public class PendingMove extends AbstractBuildable {
         return true;
     }
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     private static void updateGTIfNeeded(TileEntity te) {
         if (te instanceof IGregTechTileEntity igte) {
             if (igte instanceof BaseMetaTileEntity bmte) {

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
@@ -259,7 +259,7 @@ public class BlockPropertyRegistry {
         if (Mods.IndustrialCraft2.isModLoaded()) initIC2();
         if (Mods.ArchitectureCraft.isModLoaded()) initArch();
         if (Mods.FloodLights.isModLoaded()) initFloodLights();
-        if (Mods.GregTech.isModLoaded()) initGT5u();
+        if (Mods.GregTechNH.isModLoaded()) initGT5u();
         if (Mods.AE2Stuff.isModLoaded()) initAE2Stuff();
         if (Mods.EnderStorage.isModLoaded()) initEnderStorage();
     }

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/compat/BlockPropertyRegistry.java
@@ -1061,7 +1061,7 @@ public class BlockPropertyRegistry {
 
     // #region GT5u
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     private static void initGT5u() {
         registerIntrinsicProperty(GregTechAPI.sBlockMachines, new MEHatchCapacityProperty<>(MTEHatchOutputBusME.class));
         registerIntrinsicProperty(GregTechAPI.sBlockMachines, new MEHatchCapacityProperty<>(MTEHatchOutputME.class));

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/MMItems.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/MMItems.java
@@ -25,7 +25,7 @@ public class MMItems {
     }
 
     @Optional({
-        Names.GREG_TECH, Names.APPLIED_ENERGISTICS2
+        Names.GREG_TECH_NH, Names.APPLIED_ENERGISTICS2
     })
     public static void registerMultis() {
         MMItemList.UplinkController.set(

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/MetaItem.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/MetaItem.java
@@ -182,7 +182,7 @@ public class MetaItem extends Item {
             }
         }
 
-        @Method(modid = Names.GREG_TECH)
+        @Method(modid = Names.GREG_TECH_NH)
         private static Supplier<String> getForTier(String tier) {
             var t = GTTooltipHandler.Tier.valueOf(tier);
 

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/MetaItem.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/MetaItem.java
@@ -90,7 +90,7 @@ public class MetaItem extends Item {
             }
         }
 
-        if (Mods.GregTech.isModLoaded()) {
+        if (Mods.GregTechNH.isModLoaded()) {
             IDMetaItem metaItem = MMUtils.getIndexSafe(metaItems, meta);
 
             String tooltip = metaItem != null ? getItemTier(metaItem) : null;
@@ -175,7 +175,7 @@ public class MetaItem extends Item {
         public final Supplier<String> tooltip;
 
         Tier() {
-            if (Mods.GregTech.isModLoaded()) {
+            if (Mods.GregTechNH.isModLoaded()) {
                 tooltip = getForTier(name());
             } else {
                 tooltip = () -> null;

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/ItemMatterManipulator.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/ItemMatterManipulator.java
@@ -921,7 +921,7 @@ public class ItemMatterManipulator extends Item implements ISpecialElectricItem,
         BlockSpec cable = new BlockSpec();
 
         if (hit != null) {
-            if (Mods.GregTech.isModLoaded()) {
+            if (Mods.GregTechNH.isModLoaded()) {
                 MMUtils.getGTCable(cable, world, hit.blockX, hit.blockY, hit.blockZ);
             }
 

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/MMState.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/MMState.java
@@ -62,7 +62,6 @@ import com.recursive_pineapple.matter_manipulator.common.persist.UIDJsonAdapter;
 import com.recursive_pineapple.matter_manipulator.common.persist.WeightedListJsonAdapter;
 import com.recursive_pineapple.matter_manipulator.common.uplink.IUplinkMulti;
 import com.recursive_pineapple.matter_manipulator.common.utils.MMUtils;
-import com.recursive_pineapple.matter_manipulator.common.utils.Mods;
 import com.recursive_pineapple.matter_manipulator.common.utils.Mods.Names;
 
 import org.joml.Vector3i;

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/MMState.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/MMState.java
@@ -3,7 +3,7 @@ package com.recursive_pineapple.matter_manipulator.common.items.manipulator;
 import static com.recursive_pineapple.matter_manipulator.common.utils.MMUtils.min;
 import static com.recursive_pineapple.matter_manipulator.common.utils.MMUtils.signum;
 import static com.recursive_pineapple.matter_manipulator.common.utils.Mods.AppliedEnergistics2;
-import static com.recursive_pineapple.matter_manipulator.common.utils.Mods.GregTech;
+import static com.recursive_pineapple.matter_manipulator.common.utils.Mods.GregTechNH;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -62,6 +62,7 @@ import com.recursive_pineapple.matter_manipulator.common.persist.UIDJsonAdapter;
 import com.recursive_pineapple.matter_manipulator.common.persist.WeightedListJsonAdapter;
 import com.recursive_pineapple.matter_manipulator.common.uplink.IUplinkMulti;
 import com.recursive_pineapple.matter_manipulator.common.utils.MMUtils;
+import com.recursive_pineapple.matter_manipulator.common.utils.Mods;
 import com.recursive_pineapple.matter_manipulator.common.utils.Mods.Names;
 
 import org.joml.Vector3i;
@@ -490,7 +491,7 @@ public class MMState {
         } else {
             Block block = Block.getBlockFromItem(config.cables.getItem());
 
-            if (GregTech.isModLoaded()) {
+            if (GregTechNH.isModLoaded()) {
                 getGTCables(a, b, out, block, world, config.cables);
             }
 

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/MMState.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/items/manipulator/MMState.java
@@ -503,7 +503,7 @@ public class MMState {
         return out;
     }
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     private void getGTCables(Vector3i a, Vector3i b, List<PendingBlock> out, Block block, World world, ImmutableBlockSpec cable) {
         if (block instanceof BlockMachines) {
             int end = 0, start = 0;

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/networking/Messages.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/networking/Messages.java
@@ -230,7 +230,7 @@ public enum Messages {
         }
 
         @Optional({
-            Names.GREG_TECH, Names.APPLIED_ENERGISTICS2
+            Names.GREG_TECH_NH, Names.APPLIED_ENERGISTICS2
         })
         private void setState(World world, int x, int y, int z, UplinkState state) {
             if (world.getTileEntity(x, y, z) instanceof IGregTechTileEntity igte) {

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/networking/Messages.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/networking/Messages.java
@@ -221,7 +221,7 @@ public enum Messages {
             World theWorld = Minecraft.getMinecraft().theWorld;
 
             if (theWorld.provider.dimensionId == packet.worldId) {
-                if (Mods.GregTech.isModLoaded() && Mods.AppliedEnergistics2.isModLoaded()) {
+                if (Mods.GregTechNH.isModLoaded() && Mods.AppliedEnergistics2.isModLoaded()) {
                     Location l = packet.getLocation();
 
                     setState(l.getWorld(), l.x, l.y, l.z, packet.getState());

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/InventoryAdapter.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/InventoryAdapter.java
@@ -26,7 +26,7 @@ import tectech.thing.metaTileEntity.hatch.MTEHatchRack;
 
 public enum InventoryAdapter {
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     QCRack {
 
         @Override
@@ -59,7 +59,7 @@ public enum InventoryAdapter {
         }
     },
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     GTUnrestricted {
 
         @Override
@@ -78,7 +78,7 @@ public enum InventoryAdapter {
         }
     },
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     GTNoop {
 
         @Override
@@ -123,7 +123,7 @@ public enum InventoryAdapter {
         }
     },
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     GT {
 
         @Override

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/MMUtils.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/MMUtils.java
@@ -733,7 +733,7 @@ public class MMUtils {
         }
     }
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     public static boolean isStockingBus(IInventory inv) {
         if (inv instanceof BaseMetaTileEntity base && base.getMetaTileEntity() instanceof MTEHatchInputBusME) {
             return true;
@@ -742,7 +742,7 @@ public class MMUtils {
         }
     }
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     public static boolean isStockingHatch(IFluidHandler tank) {
         if (tank instanceof BaseMetaTileEntity base && base.getMetaTileEntity() instanceof MTEHatchInputME) {
             return true;
@@ -1446,7 +1446,7 @@ public class MMUtils {
         return block;
     }
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     public static boolean isGTMachine(ImmutableBlockSpec spec) {
         if (spec.getBlock() instanceof BlockMachines) {
             if (getIndexSafe(GregTechAPI.METATILEENTITIES, spec.getItemMeta()) != null) { return true; }
@@ -1455,7 +1455,7 @@ public class MMUtils {
         return false;
     }
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     public static boolean isGTCable(ImmutableBlockSpec spec) {
         if (spec.getBlock() instanceof BlockMachines) {
             if (getIndexSafe(GregTechAPI.METATILEENTITIES, spec.getItemMeta()) instanceof IConnectable) { return true; }
@@ -1492,7 +1492,7 @@ public class MMUtils {
         return false;
     }
 
-    @Optional(Names.GREG_TECH)
+    @Optional(Names.GREG_TECH_NH)
     public static boolean getGTCable(BlockSpec spec, World world, int x, int y, int z) {
         if (world.getTileEntity(x, y, z) instanceof IGregTechTileEntity igte && igte.getMetaTileEntity() instanceof IConnectable) {
             spec.setObject(Item.getItemFromBlock(world.getBlock(x, y, z)), igte.getMetaTileID());

--- a/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
+++ b/src/main/java/com/recursive_pineapple/matter_manipulator/common/utils/Mods.java
@@ -26,6 +26,7 @@ public enum Mods implements IMod {
     GalacticraftCore(Names.GALACTICRAFT_CORE),
     GalaxySpace(Names.GALAXY_SPACE),
     GregTech(Names.GREG_TECH),
+    GregTechNH(Names.GREG_TECH_NH),
     GTPlusPlus(Names.G_T_PLUS_PLUS),
     GTNHIntergalactic(Names.GTNH_INTERGALACTIC),
     GraviSuite(Names.GRAVI_SUITE),
@@ -63,6 +64,7 @@ public enum Mods implements IMod {
         public static final String GALACTICRAFT_CORE = "GalacticraftCore";
         public static final String GALAXY_SPACE = "GalaxySpace";
         public static final String GREG_TECH = "gregtech";
+        public static final String GREG_TECH_NH = "gregtech_nh";
         public static final String GRAVI_SUITE = "GraviSuite";
         public static final String G_T_PLUS_PLUS = "miscutils";
         public static final String GTNH_INTERGALACTIC = "gtnhintergalactic";


### PR DESCRIPTION
I added a new `Mods` and `Mods.Names` entry to check if the GTNH fork of gregtech (`gregtech_nh`) is loaded.
This fixes `NoClassDefFoundError` when trying to use MM with other forks of gregtech.

I created new entries to leave open the possibility of eventually adding support for GT6 or other GT forks. Feel free to not merge this and just change `Names.GREG_TECH` to be `"gregtech_nh"` if you don't feel like ever supporting those.

I've tested that the GT5u compatibility still works and have confirmed that it no longer crashes with GT6.